### PR TITLE
Adds a warning to plotFSDP to not call the function with a dataframe for reg

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '118206725'
+ValidationKey: '118308582'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,11 +4,13 @@ on:
   push:
     branches: [main, master]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main, master]
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ type: software
 title: |-
   m4fsdp: MAgPIE outputs R package for MAgPIE version 4.x to create outputs
       for FSDP project
-version: 0.58.25
-date-released: '2025-07-24'
+version: 0.58.26
+date-released: '2025-08-07'
 abstract: Output routines for extracting results from the MAgPIE framework (versions
   4.x) for the FSDP project.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: m4fsdp
 Title: MAgPIE outputs R package for MAgPIE version 4.x to create outputs
     for FSDP project
-Version: 0.58.25
-Date: 2025-07-24
+Version: 0.58.26
+Date: 2025-08-07
 Authors@R: c(
     person("Benjamin Leon", "Bodirsky", , "bodirsky@pik-potsdam.de", role = c("aut", "cre")),
     person("David", "Chen", , "davidch@pik-potsdam.de", role = "aut"),

--- a/R/plotFSDP.R
+++ b/R/plotFSDP.R
@@ -4,7 +4,7 @@
 #' @export
 #'
 #' @param outputfolder output folder
-#' @param reg rds file or data.frame with all MAgPIE runs, produced with FSDP_collect.R output script. NULL will automatically detect the most recent version.
+#' @param reg rds file of all MAgPIE runs, produced with FSDP_collect.R output script. NULL will automatically detect the most recent version.
 #' @param iso rds file or data.frame with all MAgPIE runs, produced with FSDP_collect.R output script. NULL will automatically detect the most recent version.
 #' @param grid rds file or data.frame with all MAgPIE runs, produced with FSDP_collect.R output script. NULL will automatically detect the most recent version.#' @details uses the most recent vXX_reg/grid/iso.rds files in the "output" folder by default
 #' @param val rds file or data.frame with all MAgPIE runs, produced with FSDP_collect.R output script. NULL will automatically detect the most recent version.#' @return plots in "output" folder
@@ -19,6 +19,11 @@ plotFSDP <- function(outputfolder = "output", reg = NULL, iso = NULL, grid = NUL
     a <- list.files(outputfolder,pattern = glob2rx("v*FSDP_reg.rds"))
     a <- a[order(a,decreasing = TRUE)][1]
     reg <- file.path(outputfolder,a)
+  } else if (is.data.frame(reg)) {
+    # Passing a data.frame will fail when passing dirFsdp = NULL,
+    # as the initialization of dirFsdp currently assumes that
+    # reg is a filename
+    warning("Passing a data.frame to reg in plotFSDP is currently not supported.")
   }
 
   if(is.null(iso)) {
@@ -45,7 +50,7 @@ plotFSDP <- function(outputfolder = "output", reg = NULL, iso = NULL, grid = NUL
   }
 
   if(is.null(dirFsdp)) {
-    if (grepl("HRc1000", reg) & !grepl("HRc1000", outputfolder)) {
+    if (grepl("HRc1000", reg) && !grepl("HRc1000", outputfolder)) {
       a <- list.dirs(paste0(outputfolder, "/HRc1000"), recursive = FALSE)
       a <- a[grep("FSECe_FSDP", a)]
       dirFsdp <- a[order(a, decreasing = TRUE)][1]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MAgPIE outputs R package for MAgPIE version 4.x to create outputs
     for FSDP project
 
-R package **m4fsdp**, version **0.58.25**
+R package **m4fsdp**, version **0.58.26**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/m4fsdp)](https://cran.r-project.org/package=m4fsdp) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7899913.svg)](https://doi.org/10.5281/zenodo.7899913) [![R build status](https://github.com/pik-piam/m4fsdp/workflows/check/badge.svg)](https://github.com/pik-piam/m4fsdp/actions) [![codecov](https://codecov.io/gh/pik-piam/m4fsdp/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/m4fsdp) [![r-universe](https://pik-piam.r-universe.dev/badges/m4fsdp)](https://pik-piam.r-universe.dev/builds)
 
@@ -40,7 +40,7 @@ In case of questions / problems please contact Benjamin Leon Bodirsky <bodirsky@
 
 To cite package **m4fsdp** in publications use:
 
-Bodirsky B, Chen D, Crawford M, Leip D, von Jeetze P, Beier F, Molina Bacca E, Dietrich J, Humpenoeder F (2025). "m4fsdp: MAgPIE outputs R package for MAgPIE version 4.x to create outputs for FSDP project." doi:10.5281/zenodo.7899913 <https://doi.org/10.5281/zenodo.7899913>, Version: 0.58.25, <https://github.com/pik-piam/m4fsdp>.
+Bodirsky B, Chen D, Crawford M, Leip D, von Jeetze P, Beier F, Molina Bacca E, Dietrich J, Humpenoeder F (2025). "m4fsdp: MAgPIE outputs R package for MAgPIE version 4.x to create outputs for FSDP project." doi:10.5281/zenodo.7899913 <https://doi.org/10.5281/zenodo.7899913>, Version: 0.58.26, <https://github.com/pik-piam/m4fsdp>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,9 +50,9 @@ A BibTeX entry for LaTeX users is
     for FSDP project},
   author = {Benjamin Leon Bodirsky and David Chen and Michael Crawford and Debbora Leip and Patrick {von Jeetze} and Felicitas Beier and Edna {Molina Bacca} and Jan Philipp Dietrich and Florian Humpenoeder},
   doi = {10.5281/zenodo.7899913},
-  date = {2025-07-24},
+  date = {2025-08-07},
   year = {2025},
   url = {https://github.com/pik-piam/m4fsdp},
-  note = {Version: 0.58.25},
+  note = {Version: 0.58.26},
 }
 ```

--- a/man/plotFSDP.Rd
+++ b/man/plotFSDP.Rd
@@ -18,7 +18,7 @@ plotFSDP(
 \arguments{
 \item{outputfolder}{output folder}
 
-\item{reg}{rds file or data.frame with all MAgPIE runs, produced with FSDP_collect.R output script. NULL will automatically detect the most recent version.}
+\item{reg}{rds file of all MAgPIE runs, produced with FSDP_collect.R output script. NULL will automatically detect the most recent version.}
 
 \item{iso}{rds file or data.frame with all MAgPIE runs, produced with FSDP_collect.R output script. NULL will automatically detect the most recent version.}
 


### PR DESCRIPTION
Passing a dataframe does currently (under R-4.3 on the cluster) not work properly anymore. As it may result in unexpected behavior, this adds a warning when a dataframe is passed.